### PR TITLE
Add TradeOS Vault listing and update README for contract schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A comprehensive registry of smart contracts deployed on the Xion blockchain, wit
 
 ## Overview
 
-This repository maintains a curated list of all smart contracts deployed on Xion mainnet, including:
-- Contract metadata (name, description, author)
-- Deployment information (code ID, hash, governance)
-- Testnet deployment status
-- Release and documentation links
+This repository maintains a curated list of CosmWasm contracts relevant to Xion, including:
+- Contract metadata (`name`, `description`, `author`, `deprecated`)
+- Mainnet deployment details (`mainnet.code_id`, `mainnet.hash`, `mainnet.governance`) when applicable
+- Optional testnet deployment records (`testnet` block with code ID, hash, network, deployer, timestamp)
+- Release references (`release.url`, `release.version`)
 
 ## Features
 
@@ -73,15 +73,48 @@ deployed-contract-listings/
 
 ## Contract Data Format
 
-Each contract in `contracts.json` follows this structure:
+The file is a **JSON array** of contract objects. Extra top-level keys on a contract are not allowed (validation fails on unknown properties).
+
+### Required fields (every entry)
+
+| Field | Type | Notes |
+|-------|------|--------|
+| `name` | string | Non-empty display name |
+| `description` | string | Free-text description |
+| `deprecated` | boolean | Whether the listing is considered deprecated |
+| `release` | object | `url` (must start with `https://`), `version` (non-empty string; tag, PR link label, commit ref, etc.) |
+| `author` | object | `name`, `url` (must start with `https://`) |
+
+### Optional: `mainnet`
+
+If present:
+
+| Field | Type | Notes |
+|-------|------|--------|
+| `code_id` | string | Digits only (e.g. `"42"`) |
+| `hash` | string | Exactly 64 hexadecimal characters (checksum byte order as stored on chain) |
+| `governance` | string | Either `Genesis` or a numeric governance proposal ID (digits only) |
+
+`mainnet` may be omitted for **testnet-only** listings (e.g. work not yet on mainnet). Those entries must appear **after** every entry that includes `mainnet` (see ordering below).
+
+### Optional: `testnet`
+
+If present, all of the following are required:
+
+| Field | Type | Notes |
+|-------|------|--------|
+| `code_id` | string | Digits only |
+| `hash` | string | 64 hex characters |
+| `network` | string | e.g. `xion-testnet-2` |
+| `deployed_by` | string | Deployer address, `xion` + bech32 payload |
+| `deployed_at` | string | UTC timestamp `YYYY-MM-DDTHH:mm:ss.sssZ` |
+
+### Example
 
 ```json
 {
   "name": "Contract Name",
   "description": "Contract description",
-  "code_id": "1",
-  "hash": "SHA256_HASH",
-  "governance": "Genesis | <proposal_id>",
   "deprecated": false,
   "release": {
     "url": "https://github.com/...",
@@ -90,6 +123,11 @@ Each contract in `contracts.json` follows this structure:
   "author": {
     "name": "Author Name",
     "url": "https://..."
+  },
+  "mainnet": {
+    "code_id": "1",
+    "hash": "SHA256_HASH",
+    "governance": "Genesis"
   },
   "testnet": {
     "code_id": "501",
@@ -100,6 +138,14 @@ Each contract in `contracts.json` follows this structure:
   }
 }
 ```
+
+The placeholders `SHA256_HASH` / `TESTNET_HASH` are illustrative only; in `contracts.json` each `hash` must be the real **64-character hexadecimal** checksum from chain (see tables above). Use a full `xion1…` testnet deployer address where required.
+
+### Ordering rules
+
+- Entries **with** `mainnet` must be sorted by ascending `mainnet.code_id` (numeric order). Gaps between IDs are OK.
+- After the last mainnet-backed entry, you may append entries that **omit** `mainnet` (typically testnet-only). An entry with `mainnet` must not appear after such a row.
+- `mainnet.code_id` values must be **unique** across the file.
 
 ## Scripts
 
@@ -112,10 +158,10 @@ npm run validate
 ```
 
 This checks:
-- Required fields are present
-- Data types are correct
-- Code IDs are unique and ordered
-- Hash format is valid
+- Required fields and types match `scripts/validate.js` (no extra properties)
+- `mainnet.code_id` values are unique and listed in non-decreasing order
+- `mainnet`-less entries appear only after all `mainnet` entries
+- `mainnet` / `testnet` hashes are 64 hex characters; `governance` matches `Genesis` or digits
 
 ### Verification
 
@@ -154,8 +200,8 @@ npm run build-site
 
 1. **Via Pull Request** (Recommended):
    - Fork this repository
-   - Add your contract to `contracts.json` in the correct position (ordered by code_id)
-   - Ensure all required fields are filled
+   - Add your contract to `contracts.json` in the correct position: insert by ascending `mainnet.code_id` when `mainnet` is present; append at the **end** if the entry has no `mainnet`
+   - Fill `release` and `author` URLs with `https://` links; set `deprecated` explicitly
    - Run `npm run validate` to check formatting
    - Submit a pull request
 
@@ -183,11 +229,8 @@ We welcome contributions! Please:
 
 ## CI/CD
 
-GitHub Actions automatically:
-- Validates `contracts.json` on every push and PR
-- Verifies contracts against chain data
-- Builds and deploys the GitHub Pages site
-- Runs on changes to contracts or site files
+- **Validate** workflow ([`.github/workflows/validate.yml`](.github/workflows/validate.yml)): on pushes to `main` and on PRs when `contracts.json` or validation/verify scripts change — runs `npm run validate` and `npm run verify` (verify is allowed to fail without failing the job).
+- **Deploy GitHub Pages** ([`.github/workflows/deploy-site.yml`](.github/workflows/deploy-site.yml)): on pushes to `main` when contracts, `scripts/build-site.js`, or `docs/**` change (or via `workflow_dispatch`) — validates, runs `npm run build-site`, then publishes `docs/`.
 
 ## License
 

--- a/contracts.json
+++ b/contracts.json
@@ -1504,6 +1504,31 @@
     }
   },
   {
+    "name": "TradeOS Vault Contract",
+    "description": "TradeOS Vault contract: claim verification, ownership, and emergency withdrawals for the TradeOS vault on XION",
+    "release": {
+      "url": "https://github.com/burnt-labs/tradeos-cw-sc",
+      "version": "v0.1.0"
+    },
+    "author": {
+      "name": "Burnt Labs",
+      "url": "https://burnt.com"
+    },
+    "deprecated": false,
+    "mainnet": {
+      "code_id": "66",
+      "hash": "45055180AB8DCCBF88F27FEC06765F58F95D55199480374377A61481E965315C",
+      "governance": "56"
+    },
+    "testnet": {
+      "code_id": "2026",
+      "hash": "45055180AB8DCCBF88F27FEC06765F58F95D55199480374377A61481E965315C",
+      "network": "xion-testnet-2",
+      "deployed_by": "xion1epzznazp28up4asses7jdcyqnw3n8lu7f5g9xs",
+      "deployed_at": "2026-03-12T14:35:08.568Z"
+    }
+  },
+  {
     "name": "Opacity Verifier",
     "description": "Verifies Opacity Network signatures for TEE-based attestations on XION",
     "release": {

--- a/docs/contracts-data.js
+++ b/docs/contracts-data.js
@@ -1,6 +1,6 @@
 // Auto-generated from contracts.json - DO NOT EDIT DIRECTLY
-// Generated on 2026-02-25T17:28:27.692Z
-// Total contracts: 62
+// Generated on 2026-03-30T13:10:40.474Z
+// Total contracts: 63
 
 const contractsData = [
   {
@@ -1505,6 +1505,31 @@ const contractsData = [
       "network": "xion-testnet-2",
       "deployed_by": "xion15r5yxaeqwlx5zz5f2vwg87vz3m7d6dd5pdd6qp",
       "deployed_at": "2025-12-31T00:00:00.000Z"
+    }
+  },
+  {
+    "name": "TradeOS CosmWasm",
+    "description": "TradeOS CosmWasm contract: claim verification, ownership, and emergency withdrawals for the TradeOS stack on XION",
+    "release": {
+      "url": "https://github.com/burnt-labs/tradeos-cw-sc",
+      "version": "v0.1.0"
+    },
+    "author": {
+      "name": "Burnt Labs",
+      "url": "https://burnt.com"
+    },
+    "deprecated": false,
+    "mainnet": {
+      "code_id": "66",
+      "hash": "45055180AB8DCCBF88F27FEC06765F58F95D55199480374377A61481E965315C",
+      "governance": "56"
+    },
+    "testnet": {
+      "code_id": "2026",
+      "hash": "45055180AB8DCCBF88F27FEC06765F58F95D55199480374377A61481E965315C",
+      "network": "xion-testnet-2",
+      "deployed_by": "xion1epzznazp28up4asses7jdcyqnw3n8lu7f5g9xs",
+      "deployed_at": "2026-03-12T14:35:08.568Z"
     }
   },
   {

--- a/docs/contracts-data.js
+++ b/docs/contracts-data.js
@@ -1,5 +1,5 @@
 // Auto-generated from contracts.json - DO NOT EDIT DIRECTLY
-// Generated on 2026-03-30T13:10:40.474Z
+// Generated on 2026-03-30T14:05:44.703Z
 // Total contracts: 63
 
 const contractsData = [
@@ -1508,8 +1508,8 @@ const contractsData = [
     }
   },
   {
-    "name": "TradeOS CosmWasm",
-    "description": "TradeOS CosmWasm contract: claim verification, ownership, and emergency withdrawals for the TradeOS stack on XION",
+    "name": "TradeOS Vault Contract",
+    "description": "TradeOS Vault contract: claim verification, ownership, and emergency withdrawals for the TradeOS vault on XION",
     "release": {
       "url": "https://github.com/burnt-labs/tradeos-cw-sc",
       "version": "v0.1.0"


### PR DESCRIPTION
## Summary

- Add **TradeOS Vault** contract to `contracts.json` (mainnet code ID 66, governance proposal 56) with matching testnet metadata.
- Regenerate `docs/contracts-data.js` for the GitHub Pages site.
- Update **README** to match the current `contracts.json` shape (nested `mainnet` / `testnet`, ordering rules, validation notes, CI workflows) and keep the example hashes as placeholders.

## Verification

- `npm run validate` (recommended on CI)

Made with [Cursor](https://cursor.com)