### PR TITLE
ci: restore verify-contracts workflow and switch to pnpm/node24

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -26,20 +26,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: '24'
+          cache: 'pnpm'
       
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
       
       - name: Validate contracts.json
-        run: npm run validate
+        run: pnpm validate
       
       - name: Build site data
-        run: npm run build-site
+        run: pnpm build-site
       
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/verify-contracts.yml
+++ b/.github/workflows/verify-contracts.yml
@@ -1,38 +1,42 @@
-name: Validate Contracts
+name: Verify Contracts
 
 on:
-  pull_request:
-    paths:
-      - 'contracts.json'
+  schedule:
+    - cron: '0 0 * * *'  # Run daily at midnight UTC
+  workflow_dispatch:  # Allow manual trigger
   push:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - 'contracts.json'
-      - 'scripts/validate.js'
       - 'scripts/verify-contracts.js'
+      - '.github/workflows/verify-contracts.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
-  validate:
+  verify:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: 'pnpm'
-      
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      
-      - name: Validate contracts.json format
-        run: pnpm validate
-      
+
       - name: Verify contracts against chain
         run: pnpm verify
-        continue-on-error: true # Don't fail CI if chain verification has issues


### PR DESCRIPTION
## Summary

Restores the `verify-contracts.yml` workflow that was removed when the contract registry moved out of `burnt-labs/contracts` ([commit 1271bd6](https://github.com/burnt-labs/contracts/commit/1271bd6a63bb29e3c6d798897e4d5bae8f96860b)). The `scripts/verify-contracts.js` it invokes already exists in this repo.

Also aligns all three workflows with the repo's declared toolchain (`packageManager: pnpm@9.15.4`, `@types/node: ^24`):

- Restore `.github/workflows/verify-contracts.yml` — daily cron (`0 0 * * *`), `workflow_dispatch`, and push-to-main triggers; verifies deployed contracts against chain.
- Switch all workflows (`validate.yml`, `deploy-site.yml`, `verify-contracts.yml`) from `npm ci`/`npm run` to `pnpm install --frozen-lockfile`/`pnpm <script>` via `pnpm/action-setup@v4` with `cache: 'pnpm'`.
- Bump `node-version` from `20` to `24`.

## Why

The existing workflows used `npm` despite the repo declaring pnpm as its package manager and shipping a `pnpm-lock.yaml`. They also targeted Node 20 while `@types/node` indicates Node 24. This brings the CI in line with the actual toolchain.