### PR TITLE
Add MetaAccount (ZK-Email) code id 1880 on xion-testnet-2

### DIFF
--- a/contracts.json
+++ b/contracts.json
@@ -1550,10 +1550,10 @@
   },
   {
     "name": "MetaAccount (ZK-Email)",
-    "description": "Xion MetaAccount with ZK-Email authenticator support. cw2 contract info reports name 'account' version 0.1.1. Supports the Secp256K1, Secp256R1/Passkey, Ed25519, EthWallet, JWT and ZKEmail authenticator types. Allowed and pinned on xion-testnet-2 by governance proposal 63.",
+    "description": "Xion MetaAccount with ZK-Email authenticator support. cw2 contract info reports name 'account' version 0.1.1. Supports the Secp256K1, Secp256R1/Passkey, Ed25519, EthWallet, JWT and ZKEmail authenticator types. Allowed and pinned on xion-testnet-2 by governance proposal 63: https://github.com/burnt-labs/xion-testnet-2/pull/48",
     "release": {
-      "url": "https://github.com/burnt-labs/contracts",
-      "version": "0.1.1"
+      "url": "https://explorer.burnt.com/xion-testnet-2/tx/7E172E52BF0DCE43C44E173C1D02E058E835430709D02B6006E6DBBA177526E6",
+      "version": "7E172E52BF0DCE43C44E173C1D02E058E835430709D02B6006E6DBBA177526E6"
     },
     "author": {
       "name": "Burnt Labs",
@@ -1565,7 +1565,7 @@
       "hash": "D27A379FF65EB47A9E538E3A3D46101DE2A6C0B86BA3D0BF014C0403849414E6",
       "network": "xion-testnet-2",
       "deployed_by": "xion16kq8j4le6zjthc5khw5w3lx7mq5q2y9sj0qze4",
-      "deployed_at": "2025-12-31T00:00:00.000Z"
+      "deployed_at": "2026-01-14T09:31:32.000Z"
     }
   }
 ]

--- a/contracts.json
+++ b/contracts.json
@@ -1547,5 +1547,25 @@
       "deployed_by": "xion1l5fq4la4jjh827wnay8g022z69mumz84jwl6zt",
       "deployed_at": "2025-12-12T00:00:00.000Z"
     }
+  },
+  {
+    "name": "MetaAccount (ZK-Email)",
+    "description": "Xion MetaAccount with ZK-Email authenticator support. cw2 contract info reports name 'account' version 0.1.1. Supports the Secp256K1, Secp256R1/Passkey, Ed25519, EthWallet, JWT and ZKEmail authenticator types. Allowed and pinned on xion-testnet-2 by governance proposal 63.",
+    "release": {
+      "url": "https://github.com/burnt-labs/contracts",
+      "version": "0.1.1"
+    },
+    "author": {
+      "name": "Burnt Labs",
+      "url": "https://burnt.com"
+    },
+    "deprecated": false,
+    "testnet": {
+      "code_id": "1880",
+      "hash": "D27A379FF65EB47A9E538E3A3D46101DE2A6C0B86BA3D0BF014C0403849414E6",
+      "network": "xion-testnet-2",
+      "deployed_by": "xion16kq8j4le6zjthc5khw5w3lx7mq5q2y9sj0qze4",
+      "deployed_at": "2025-12-31T00:00:00.000Z"
+    }
   }
 ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^0.36.1
         version: 0.36.1
       axios:
-        specifier: ^1.12.2
-        version: 1.12.2
+        specifier: ^1.13.5
+        version: 1.19.0
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
@@ -243,6 +243,10 @@ packages:
   '@types/node@24.7.1':
     resolution: {integrity: sha512-CmyhGZanP88uuC5GpWU9q+fI61j2SkhO3UGMUdfYRE6Bcy0ccyzn1Rqj9YAB/ZY4kOXmNf0ocah5GtphmLMP6Q==}
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -253,8 +257,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.12.2:
-    resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
+  axios@1.19.0:
+    resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -358,8 +362,17 @@ packages:
       debug:
         optional: true
 
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   fsevents@2.3.3:
@@ -411,6 +424,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
@@ -427,6 +444,10 @@ packages:
     resolution: {integrity: sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==}
     engines: {node: '>=12'}
     hasBin: true
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -479,8 +500,9 @@ packages:
     resolution: {integrity: sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==}
     engines: {node: '>= 10.12'}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
@@ -546,6 +568,7 @@ packages:
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   ws@7.5.10:
     resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
@@ -754,6 +777,12 @@ snapshots:
     dependencies:
       undici-types: 7.14.0
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
@@ -762,13 +791,15 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.12.2:
+  axios@1.19.0:
     dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   base64-js@1.5.1: {}
 
@@ -846,7 +877,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   esbuild@0.25.10:
     optionalDependencies:
@@ -881,12 +912,14 @@ snapshots:
 
   follow-redirects@1.15.11: {}
 
-  form-data@4.0.4:
+  follow-redirects@1.16.0: {}
+
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   fsevents@2.3.3:
@@ -941,6 +974,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   he@1.2.0: {}
 
   html-encoding-sniffer@3.0.0:
@@ -972,6 +1009,13 @@ snapshots:
       url-join: 4.0.1
     transitivePeerDependencies:
       - debug
+      - supports-color
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
       - supports-color
 
   iconv-lite@0.6.3:
@@ -1011,7 +1055,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@2.1.0: {}
 
   qs@6.14.0:
     dependencies:


### PR DESCRIPTION
Registers code id **1880** on `xion-testnet-2` — the account contract that [`xion-testnet-2` proposal 63](https://github.com/burnt-labs/xion-testnet-2/pull/48) adds to the abstract account module's `allowed_code_ids` and pins.

It was missing from `contracts.json` even though the apps already reference it (`account-abstraction-api` `wrangler.jsonc` has `CODE_ID: "1880"`, and `xion-frontends` uses its checksum as the account-migration target).

## What it is

Verified by downloading the code from chain and inspecting the wasm:

- sha256 of the bytes = `d27a379f…49414e6`, matching the chain's `data_hash`
- embedded cw2 contract info: name `account`, version `0.1.1`
- exports `before_tx` / `after_tx`
- crate paths include `contracts/account/src/auth/zkemail.rs`
- authenticator variants present: `Secp256K1`, `Secp256R1`/`Passkey`, `Ed25519`, `EthWallet`, `Jwt`, `ZKEmail`

## Upload provenance

A public archival LCD indexed the actual `store_code.code_id=1880` transaction:

- transaction: [`7E172E52…526E6`](https://explorer.burnt.com/xion-testnet-2/tx/7E172E52BF0DCE43C44E173C1D02E058E835430709D02B6006E6DBBA177526E6)
- block height: `11771291`
- timestamp: `2026-01-14T09:31:32Z`
- sender: `xion16kq8j4le6zjthc5khw5w3lx7mq5q2y9sj0qze4`

The registry release link now uses that immutable upload transaction. No producing source revision is recoverable from the public repositories, so the entry does not claim a source tag or commit; `0.1.1` remains described only as embedded cw2 metadata.

## Checks

- `pnpm validate` → `✅ contracts.json is valid`
- `hash`, `deployed_by`, upload timestamp, and transaction hash all re-read from chain/indexed transaction data
- entry remains appended at the end, preserving the validator's ordering rule